### PR TITLE
Ignore unschedulable nodes

### DIFF
--- a/main.go
+++ b/main.go
@@ -81,7 +81,14 @@ func ListNodes(client clientset.Interface) ([]*v1.Node, error) {
 
 	nodes := make([]*v1.Node, 0)
 	for i := range nodeList.Items {
-		nodes = append(nodes, &nodeList.Items[i])
+		node := &nodeList.Items[i]
+
+		if node.Spec.Unschedulable {
+			logrus.Infof("Not evaluating unschedulable node %v", node.Name)
+			continue;
+		}
+
+		nodes = append(nodes, node)
 	}
 	return nodes, nil
 }


### PR DESCRIPTION
If a Pod wants to be on the Node that is currently cordoned (or unschedulable of any other reason), it will be evicted at each run without any effect, causing unnecessary restarts.

This change excludes unschedulable Nodes from evaluation.